### PR TITLE
Av bugs - increase antox FPS optimizing scala fromat conversions algorithm

### DIFF
--- a/app/src/main/scala/chat/tox/antox/av/Call.scala
+++ b/app/src/main/scala/chat/tox/antox/av/Call.scala
@@ -226,13 +226,15 @@ final case class Call(callNumber: CallNumber, contactKey: ContactKey, incoming: 
             if (active && selfState.sendingVideo && !ringing) {
               val startSendTime = System.currentTimeMillis()
               val yuvFrame = FormatConversions.nv21toYuv420(cameraFrame)
+			  //To log the delta time taken for encoding and sending in native libtoxcore
+              val yuvConvertedTime = System.currentTimeMillis()
               try {
                 ToxSingleton.toxAv.videoSendFrame(callNumber, yuvFrame.width, yuvFrame.height, yuvFrame.y, yuvFrame.u, yuvFrame.v)
               } catch {
                 case e: ToxException[_] =>
                   AntoxLog.debug("Ignoring video send frame exception.")
               }
-              println(s"sending frame took ${System.currentTimeMillis() - startSendTime}")
+              println(s"sending frame took ${System.currentTimeMillis() - startSendTime}, libtoxcore took ${System.currentTimeMillis() - yuvConvertedTime}")
             }
           })
         }

--- a/app/src/main/scala/chat/tox/antox/av/CameraDisplay.scala
+++ b/app/src/main/scala/chat/tox/antox/av/CameraDisplay.scala
@@ -2,8 +2,7 @@ package chat.tox.antox.av
 
 import android.app.Activity
 import android.content.res.Configuration
-import android.graphics.SurfaceTexture
-import android.graphics.ImageFormat 
+import android.graphics.{ImageFormat, SurfaceTexture}
 import android.hardware.Camera
 import android.hardware.Camera.PreviewCallback
 import android.view.TextureView
@@ -56,7 +55,8 @@ class CameraDisplay(activity: Activity, previewView: TextureView, previewWrapper
           try {
             val previewSize = camera.getParameters.getPreviewSize
 
-            val rotation = CameraUtils.getCameraRotation(activity, antoxCamera, hack = true)
+            //The getCameraRotation takes about 200ms per frame - needed to be optimized also, or rotate on the receiver client side
+            val rotation = 0
             val frame = NV21Frame(previewSize.width, previewSize.height, data, rotation)
 
             frameBuffer.add(frame)
@@ -68,7 +68,8 @@ class CameraDisplay(activity: Activity, previewView: TextureView, previewWrapper
       }
 
       //camera.addCallbackBuffer()
-      FormatConversions.reinit(previewSize.height * previewSize.width * (ImageFormat.getBitsPerPixel(camera.getParameters.getPreviewFormat())) / 8)
+      FormatConversions.updateFrameSettings(camera.getParameters.getPreviewSize.height * camera.getParameters.getPreviewSize.width
+          * (ImageFormat.getBitsPerPixel(camera.getParameters.getPreviewFormat())) / 8)
       camera.setPreviewCallback(previewCallback)
       camera.startPreview()
     } catch {

--- a/app/src/main/scala/chat/tox/antox/av/CameraDisplay.scala
+++ b/app/src/main/scala/chat/tox/antox/av/CameraDisplay.scala
@@ -3,6 +3,7 @@ package chat.tox.antox.av
 import android.app.Activity
 import android.content.res.Configuration
 import android.graphics.SurfaceTexture
+import android.graphics.ImageFormat 
 import android.hardware.Camera
 import android.hardware.Camera.PreviewCallback
 import android.view.TextureView
@@ -67,6 +68,7 @@ class CameraDisplay(activity: Activity, previewView: TextureView, previewWrapper
       }
 
       //camera.addCallbackBuffer()
+      FormatConversions.reinit(previewSize.height * previewSize.width * (ImageFormat.getBitsPerPixel(camera.getParameters.getPreviewFormat())) / 8)
       camera.setPreviewCallback(previewCallback)
       camera.startPreview()
     } catch {

--- a/app/src/main/scala/chat/tox/antox/av/FormatConversions.scala
+++ b/app/src/main/scala/chat/tox/antox/av/FormatConversions.scala
@@ -2,8 +2,8 @@ package chat.tox.antox.av
 
 object FormatConversions {
 
-  object Arrays {
-	//Vars below are default for 640x480 resolution for 12bits/pixel
+  object frameSettings {
+    //Vars below are default for 640x480 resolution and 12bits/pixel
     var bytesNum = 460800
     var uvDataNum = (bytesNum / 3).toInt
     var yLength = (bytesNum / 1.5).toInt
@@ -12,45 +12,41 @@ object FormatConversions {
     var v = new Array[Byte](bytesNum / 6)
   }
 
-  def arrays: Arrays
-  def reinit(bytesNum:int): Unit = {
-	arrays.bytesNum = bytesNum
-	arrays.uvDataNum = (bytesNum / 3).toInt
-	arrays.yLength = (bytesNum / 1.5).toInt
-	arrays.y = new Array[Byte](yLength)
-	arrays.u = new Array[Byte](bytesNum / 6)
-	arrays.v = new Array[Byte](bytesNum / 6)
+  def updateFrameSettings(bytesNum: Int): Unit = {
+    frameSettings.bytesNum = bytesNum
+    frameSettings.uvDataNum = (bytesNum / 3).toInt
+    frameSettings.yLength = (bytesNum / 1.5).toInt
+    frameSettings.y = new Array[Byte](frameSettings.yLength)
+    frameSettings.u = new Array[Byte](bytesNum / 6)
+    frameSettings.v = new Array[Byte](bytesNum / 6)
   }
 
   def nv21toYuv420(nv21: NV21Frame): YuvFrame = {
-	
-	//No need to create new array here - we do not change data elements, if don't use the Convert.rotateNV21 below
-	//when we have group chats - perhaps will need to create different arrays
+    //No need to create new array here - we do not change data elements, if don't use the Convert.rotateNV21 below
+    //when we have group chats - perhaps will need to create different arrays
     val data = nv21.data
-	
-	//TODO: uncomment the rotation when rotation function becomes faster OR the rotation can be
-	//performed on the video receiver tox client - it could be much efficient:
-	//now this operation costs 700ms per frame per 640x480 resolution on LG L65, causing FPS < 1
+
+    //TODO: uncomment the rotation when rotation function becomes faster OR the rotation can be
+    //performed on the video receiver tox client - it could be much efficient:
+    //now this operation costs 700ms per frame per 640x480 resolution on LG L65, causing FPS < 1
     //Convert.rotateNV21(nv21.data, data, nv21.width, nv21.height, nv21.rotation)
 
-
-	//Array slicing was almost the heaviest operation here.
-	//much faster is to initialize the array in reinit() only once,
-	//and use arraycopy to fill it correctly
-    val y = arrays.y
-    System.arraycopy(data, 0, y, 0, arrays.yLength)
-    val u = arrays.u
-    val v = arrays.v
+    //Array slicing was almost the heaviest operation here.
+    //much faster is to initialize the array in reinit() only once,
+    //and use arraycopy to fill it correctly
+    val y = frameSettings.y
+    System.arraycopy(data, 0, y, 0, frameSettings.yLength)
+    val u = frameSettings.u
+    val v = frameSettings.v
 
     var i = 0
-
-	//to achieve FPS better than 25, we have to avoid even 1ms costs per frame,
-	//so better not to count the / operation over 150000 times per frame
-    while (i < arrays.uvDataNum) {
+    //to achieve FPS better than 25, we have to avoid even 1ms costs per frame,
+    //so better not to count the / operation over 150000 times per frame in while condition
+    while (i < frameSettings.uvDataNum) {
       if (i % 2 == 0) {
-        v(i >> 1) = data(arrays.yLength + i)
+        v(i >> 1) = data(frameSettings.yLength + i)
       } else {
-        u(i >> 1) = data(arrays.yLength + i)
+        u(i >> 1) = data(frameSettings.yLength + i)
       }
 
       i += 1

--- a/app/src/main/scala/chat/tox/antox/av/FormatConversions.scala
+++ b/app/src/main/scala/chat/tox/antox/av/FormatConversions.scala
@@ -1,21 +1,56 @@
 package chat.tox.antox.av
 
 object FormatConversions {
-  def nv21toYuv420(nv21: NV21Frame): YuvFrame = {
-    val data = new Array[Byte](nv21.data.length)
-    Convert.rotateNV21(nv21.data, data, nv21.width, nv21.height, nv21.rotation)
 
-    val yLength = (data.length / 1.5).toInt
-    val y = data.slice(0, yLength)
-    val u = new Array[Byte](data.length / 6)
-    val v = new Array[Byte](data.length / 6)
+  object Arrays {
+	//Vars below are default for 640x480 resolution for 12bits/pixel
+    var bytesNum = 460800
+    var uvDataNum = (bytesNum / 3).toInt
+    var yLength = (bytesNum / 1.5).toInt
+    var y = new Array[Byte](yLength)
+    var u = new Array[Byte](bytesNum / 6)
+    var v = new Array[Byte](bytesNum / 6)
+  }
+
+  def arrays: Arrays
+  def reinit(bytesNum:int): Unit = {
+	arrays.bytesNum = bytesNum
+	arrays.uvDataNum = (bytesNum / 3).toInt
+	arrays.yLength = (bytesNum / 1.5).toInt
+	arrays.y = new Array[Byte](yLength)
+	arrays.u = new Array[Byte](bytesNum / 6)
+	arrays.v = new Array[Byte](bytesNum / 6)
+  }
+
+  def nv21toYuv420(nv21: NV21Frame): YuvFrame = {
+	
+	//No need to create new array here - we do not change data elements, if don't use the Convert.rotateNV21 below
+	//when we have group chats - perhaps will need to create different arrays
+    val data = nv21.data
+	
+	//TODO: uncomment the rotation when rotation function becomes faster OR the rotation can be
+	//performed on the video receiver tox client - it could be much efficient:
+	//now this operation costs 700ms per frame per 640x480 resolution on LG L65, causing FPS < 1
+    //Convert.rotateNV21(nv21.data, data, nv21.width, nv21.height, nv21.rotation)
+
+
+	//Array slicing was almost the heaviest operation here.
+	//much faster is to initialize the array in reinit() only once,
+	//and use arraycopy to fill it correctly
+    val y = arrays.y
+    System.arraycopy(data, 0, y, 0, arrays.yLength)
+    val u = arrays.u
+    val v = arrays.v
 
     var i = 0
-    while (i < data.length / 3) {
+
+	//to achieve FPS better than 25, we have to avoid even 1ms costs per frame,
+	//so better not to count the / operation over 150000 times per frame
+    while (i < arrays.uvDataNum) {
       if (i % 2 == 0) {
-        v(i / 2) = data(yLength + i)
+        v(i >> 1) = data(arrays.yLength + i)
       } else {
-        u(i / 2) = data(yLength + i)
+        u(i >> 1) = data(arrays.yLength + i)
       }
 
       i += 1


### PR DESCRIPTION
Still, it is better to avoid these conversions at all - just use YV12 formate for camera, and no conversions needed.